### PR TITLE
edited Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# toSketch 
+# toSketch
 
 ## ( FreeCAD workbench to add toSketch Facility )
 
@@ -8,10 +8,8 @@ but no details about how it was created or Parametric properties that you can ch
 
 ## Installation
 
-* Using Addon Manager
+It can be installed via the [Addon Manager](https://github.com/FreeCAD/FreeCAD-addons) (from Tools menu)
 
-  * Click on Configure
-  * Enter https://github.com/KeithSloan/toSketch.git
 
 ## Alternative Installation
 
@@ -21,20 +19,6 @@ Clone into FreeCAD's Mod directory see https://wiki.freecadweb.org/Installing_mo
    * **git clone https://github.com/KeithSloan/toSketch.git**
 
 * Start/Restart FreeCAD
-
-## Installation with FreeCAD 0.20
-
-Use FreeCAD preferences to add the Repro to available 'Custom Repositories'
-
-![Image 13-02-2022 at 12 55](https://user-images.githubusercontent.com/2291247/153757512-fedad170-7d27-4c5f-9618-8b68ca2b6b24.jpeg)
-
-Invoke the Addon Manager - Tools | Addon manager
-
-
-Click on 'Refresh local cache'
-
-Then install
-
 
 
 ## Use
@@ -54,42 +38,42 @@ Then install
 * Select Plane in treeView
 * Click on toSketch Icon - Should create a section of the Plane and other objects
                            that is then opened as a new sketch
-                           
+
 ### Sketch to Macro ( Alpha - Under Development )
 
 * Select a sketch
 * Click on ToMacro
 
    Creates a macro name (sketch.FCMacro) in the user Macro directory
-   
+
 Currently supports ( More to follow )
-    
+
       * Points
       * Lines
       * Circles
       * ArcOfCircle
       * BSpline ( Initial Attempt )
       * Ellipse
-      
+
 When executing the macro
 
      If there is a an ActiveSketch, the geometry is added, otherwise a new sketch is created.
-     
+
 Constraints
 
      The following types of constraints are exported if present in the selected sketch.
-     
+
          * Coincident
          * Vertical
          * Horizontal
- 
-                              
+
+
 ### Section a Mesh Cross Section : to CurveFit ( Alpha - Under Development )
 
 Requires NURBS-Python ( geomdl ) see https://nurbs-python.readthedocs.io/en/5.x/
 
 * To Install
-   
+
     * From FreeCAD python console
     * **import os**
     * **print(os.environ)**
@@ -99,29 +83,29 @@ Requires NURBS-Python ( geomdl ) see https://nurbs-python.readthedocs.io/en/5.x/
 * To Use
 
     * Load/Create a Mesh
-    * Use Mesh Design workbench to create a section 
-       
+    * Use Mesh Design workbench to create a section
+
         Toobar - **Meshes | Cutting | Cross-Sections**
 
         Creates a Mesh Cross-Section
-        
+
     * Select Cross-Section in Tree View, click on 'To Sketch' icon
 
         Creates a Raw Sketch
-      
+
     * Select Created Sketch, click on 'To CurveFit' icon
 
         Creates a Sketch with some line and Curve Fitting
-        
+
 ## Constraints
 
 Note: Ideally constraints should be set on a geometric basis, however there is always
       the option to fix all points with the installable Macro SketcherFixAllPoints.FCMacro
-      see Addon Manager for installation. 
- 
-                           
-## The following are intended to help with Objects created via import of STEP files                           
-                           
+      see Addon Manager for installation.
+
+
+## The following are intended to help with Objects created via import of STEP files
+
 ### Create Scale Object : to Scale
 
 Aimed at scaling objects imported from a STEP file, provides the ability to scale a
@@ -133,7 +117,7 @@ selected Object as follows
 * The original selected object is then deleted
 * By changing the Objects Properties from the inital values of ONE the Shape of the object can be reScaled
 
-     
+
 ### Reset Origin
 
 When STEP files are imported into FreeCAD their Placements are all set to zero and the Shapes are all created accordingly.
@@ -144,30 +128,29 @@ Selecting an Object and clicking on the Reset Origin icon results in the followi
  * A new PartFeaturePython object is created and stores a copy of the selected objects Shape.
  * The Objects Placement is set based on the Shapes Bounding box and drawn at the same position.
  * The Selected Object is removed
- 
+
  The display of the Object will not change, but the Placement will be updated and it can be correctly rotated.
-     
+
  For the new object
-      
+
  * The Origin can be changed via the Object Type Parameter using the Parameter window between
-     
-    * min x/y/z 
+
+    * min x/y/z
     * Center of Mass
     * Original ( as created by STEP import )
-           
+
  * The parameter window shows readonly Bounding box info
  * The Origin type can be changed via the Objects Parameter Placement setting.
  * Apart from when the Origin Type is set to Original the Object should now rotate correctly
- 
+
  ## Acknowledgments
- 
+
  Thanks to the following FreeCAD forum members
- 
+
      * suzanne.soy
      * wmayer
      * Ed Williams edwilliams16
-     
- Icons thanks to jmaustpc    
-     
-          
 
+ Icons thanks to jmaustpc
+ 
+ 


### PR DESCRIPTION
Hello, it seems that metadata.txt has been incorporated in package.xml, or at least the "Sheetmetal WB" and other notable packages don't have this file.

I have left the text for the AddOn Manager deleting the freecad 0.20 section, and cleaned the file for trailing spaces and similar things (Emacs seems to be abel to make some cleaning over md files, so it is only a matter to issue a command).

This is what I've found in the documentation, and even in "Curves WB"  there is no sign of metadata.txt.

Regards